### PR TITLE
Add specific provider to pubish

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For older versions of Laravel (<5.5), you have to add the service provider and a
 ]
 ```
 
-Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
+Then publish the config file with `php artisan vendor:publish --provider="Aacotroneo\Saml2\Saml2ServiceProvider"`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
 
 ### Configuration
 


### PR DESCRIPTION
For Laravel < 5.5, using `php artisan vendor:publish` will publish all the vendor files in resource folder and the packages config files that the user does not intend to publish.